### PR TITLE
#975: Remove 'svm_model_type' definition for 'training'

### DIFF
--- a/python/jsonschema_definition.py
+++ b/python/jsonschema_definition.py
@@ -43,10 +43,6 @@ def jsonschema_training():
     'properties': {
       'svm_title': { 'type': 'string' },
       'svm_session_id' : { 'type': 'string' },
-      'svm_model_type': {
-        'type': 'string',
-        'enum': ['classification', 'regression']
-      },
       'svm_dataset_type': {
         'type': 'string',
         'enum': ['file_upload', 'xml_url']


### PR DESCRIPTION
Resolves #975.