### PR TITLE
#1736: redis_query.py, add missing colon for 'lrem'

### DIFF
--- a/brain/cache/redis_query.py
+++ b/brain/cache/redis_query.py
@@ -109,7 +109,7 @@ class Redis_Query(object):
 
     ## lrem: remove the first count occurences of elements equal to value
     #        within the redist list.
-    def lrem(self, name, count, value)
+    def lrem(self, name, count, value):
         self.server.lrem(name, count, value)
 
     ## lpush: push values onto the beginning of a redis list.


### PR DESCRIPTION
Resolves #1736.