### PR TITLE
#1776: redis_query.py, remove unnecessary colon

### DIFF
--- a/brain/cache/redis_query.py
+++ b/brain/cache/redis_query.py
@@ -178,7 +178,7 @@ class Redis_Query(object):
 
     ## hlen: return the number of elements within the redis hash.
     def hlen(self, name):
-        return self.server.hlen(name):
+        return self.server.hlen(name)
 
     ## hkeys: return the list of keys within the redis hash
     def hkeys(self, name):


### PR DESCRIPTION
Resolves #1776.