### PR TITLE
#1895: model_generate.py, cache 'label_encoder'

### DIFF
--- a/brain/session/model_generate.py
+++ b/brain/session/model_generate.py
@@ -97,7 +97,7 @@ class Model_Generate(Base):
             # get svm title, and cache (model, encoded labels, title)
             title = Retrieve_Entity().get_title(self.session_id)['result'][0][0]
             Cache_Model(clf).cache('svm_model', str(self.session_id) + '_' + title)
-            Cache_Model(encoded_labels).cache('svm_labels', self.session_id)
+            Cache_Model(label_encoder).cache('svm_labels', self.session_id)
             Cache_Hset().cache('svm_title', self.session_id, title)
 
             # cache svm feature labels, with respect to given session id


### PR DESCRIPTION
Resolves #1895.