### PR TITLE
#1965: install_sklearn.pp, remove '/vagrant/build/'

### DIFF
--- a/puppet/manifests/install_sklearn.pp
+++ b/puppet/manifests/install_sklearn.pp
@@ -4,12 +4,6 @@ include git
 ## define $PATH for all execs
 Exec {path => ['/usr/bin/']}
 
-## create '/vagrant/build/' directory
-file {'/vagrant/build/':
-    ensure => 'directory',
-    before => Vcsrepo['/vagrant/build/scikit-learn'],
-}
-
 ## install scikit-learn
 vcsrepo {'/vagrant/build/scikit-learn':
     ensure => present,


### PR DESCRIPTION
Resolves #1965.