### PR TITLE
#2046: Ensure upstart webcompiler scripts autostarts

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -55,6 +55,13 @@ Vagrant.configure(2) do |config|
     puppet.module_path    = "puppet/modules"
   end
 
+  ## Custom Manifest: ensure vagrant-mounted event
+  config.vm.provision "puppet" do |puppet|
+    puppet.manifests_path = "puppet/manifests"
+    puppet.manifest_file  = "vagrant_mounted.pp"
+    puppet.module_path    = "puppet/modules"
+  end
+
   ## Custom Manifest: start webserver
   #
   #  Note: future parser allow heredoc syntax in the puppet manifest (since puppet 3.5)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -56,10 +56,13 @@ Vagrant.configure(2) do |config|
   end
 
   ## Custom Manifest: ensure vagrant-mounted event
+  #
+  #  Note: future parser allow heredoc syntax in the puppet manifest (since puppet 3.5)
   config.vm.provision "puppet" do |puppet|
     puppet.manifests_path = "puppet/manifests"
     puppet.manifest_file  = "vagrant_mounted.pp"
     puppet.module_path    = "puppet/modules"
+    puppet.options        = ["--parser", "future"]
   end
 
   ## Custom Manifest: start webserver

--- a/puppet/manifests/compile_asset.pp
+++ b/puppet/manifests/compile_asset.pp
@@ -14,7 +14,7 @@ $compilers.each |Integer $index, String $compiler| {
         before => File["${compiler}-startup-script"],
     }
 
-    ## create startup script (heredoc syntax)
+    ## create startup script: for webcompilers, using heredoc syntax
     #
     #  @("EOT"), the use double quotes on the end tag, allows variable interpolation within the puppet heredoc.
     file {"${compiler}-startup-script":
@@ -65,7 +65,7 @@ $compilers.each |Integer $index, String $compiler| {
                    end script
                    | EOT
                notify  => Exec["dos2unix-upstart-${compiler}"],
-        }
+    }
 
     ## dos2unix upstart: convert clrf (windows to linux) in case host machine is windows.
     #

--- a/puppet/manifests/vagrant_mounted.pp
+++ b/puppet/manifests/vagrant_mounted.pp
@@ -1,3 +1,6 @@
+## define $PATH for all execs, and packages
+Exec {path => ['/usr/bin/']
+
 ## create startup script: for 'vagrant-mounted' event
 file {"vagrant-startup-script":
     path    => "/etc/init/workaround-vagrant-bug-6074.conf ",

--- a/puppet/manifests/vagrant_mounted.pp
+++ b/puppet/manifests/vagrant_mounted.pp
@@ -38,7 +38,7 @@ file {"vagrant-startup-script":
 #      'service' end point does not require the 'refreshonly' attribute.
 exec {"dos2unix-upstart-vagrant":
     command => "dos2unix /etc/init/workaround-vagrant-bug-6074.conf",
-    notify  => Service["vagrant"],
+    notify  => Service["workaround-vagrant-bug-6074.conf"],
 }
 
 ## start 'workaround-vagrant-bug-6074' service

--- a/puppet/manifests/vagrant_mounted.pp
+++ b/puppet/manifests/vagrant_mounted.pp
@@ -1,0 +1,29 @@
+## create startup script: for 'vagrant-mounted' event
+file {"vagrant-startup-script":
+    path    => "/etc/init/workaround-vagrant-bug-6074.conf ",
+    ensure  => 'present',
+    content => @("EOT"),
+               #!upstart
+               description workaround for https://github.com/mitchellh/vagrant/issues/6074
+
+               ## start job defined in this file after system services, and processes have already loaded
+               #       (to prevent conflict).
+               #
+               #  Note: this is a workaround for https://github.com/mitchellh/vagrant/issues/6074
+               #
+               #  @vagrant-mounted, an event that executes after the shared folder is mounted
+               #  @[2345], represents all configuration states with general linux, and networking access
+               start on (vagrant-mounted and runlevel [2345])
+
+               ## job will be blocked until the job has completely transitioned back to stopped
+               task
+
+               env MOUNTPOINT=/vagrant
+
+               script
+                   until mountpoint -q $MOUNTPOINT; do sleep 1; done
+                   /sbin/initctl emit --no-wait vagrant-mounted MOUNTPOINT=$MOUNTPOINT
+               end script
+               | EOT
+               notify  => Exec["dos2unix-upstart-${compiler}"],
+}

--- a/puppet/manifests/vagrant_mounted.pp
+++ b/puppet/manifests/vagrant_mounted.pp
@@ -37,7 +37,7 @@ file {"vagrant-startup-script":
 #      'refreshonly => true' would be implemented on the corresponding listening end point. But, the
 #      'service' end point does not require the 'refreshonly' attribute.
 exec {"dos2unix-upstart-vagrant":
-    command => "dos2unix /etc/init/vagrant.conf",
+    command => "dos2unix /etc/init/workaround-vagrant-bug-6074.conf",
     notify  => Service["vagrant"],
 }
 

--- a/puppet/manifests/vagrant_mounted.pp
+++ b/puppet/manifests/vagrant_mounted.pp
@@ -41,8 +41,8 @@ exec {"dos2unix-upstart-vagrant":
     notify  => Service["vagrant"],
 }
 
-## start vagrant service
-service {"vagrant":
+## start 'workaround-vagrant-bug-6074' service
+service {"workaround-vagrant-bug-6074.conf":
     ensure => 'running',
     enable => 'true',
 }

--- a/puppet/manifests/vagrant_mounted.pp
+++ b/puppet/manifests/vagrant_mounted.pp
@@ -1,9 +1,12 @@
+## variables
+$MOUNTPOINT
+
 ## define $PATH for all execs, and packages
 Exec {path => ['/usr/bin/']}
 
 ## create startup script: for 'vagrant-mounted' event
 file {"vagrant-startup-script":
-    path    => "/etc/init/workaround-vagrant-bug-6074.conf ",
+    path    => "/etc/init/workaround-vagrant-bug-6074.conf",
     ensure  => 'present',
     content => @("EOT"),
                #!upstart
@@ -20,11 +23,9 @@ file {"vagrant-startup-script":
                ## job will be blocked until the job has completely transitioned back to stopped
                task
 
-               env MOUNTPOINT=/vagrant
-
                script
-                   until mountpoint -q $MOUNTPOINT; do sleep 1; done
-                   /sbin/initctl emit --no-wait vagrant-mounted MOUNTPOINT=$MOUNTPOINT
+                   until mountpoint -q ${MOUNTPOINT}; do sleep 1; done
+                   /sbin/initctl emit --no-wait vagrant-mounted MOUNTPOINT=${MOUNTPOINT}
                end script
                | EOT
                notify  => Exec["dos2unix-upstart-vagrant"],

--- a/puppet/manifests/vagrant_mounted.pp
+++ b/puppet/manifests/vagrant_mounted.pp
@@ -1,5 +1,5 @@
 ## define $PATH for all execs, and packages
-Exec {path => ['/usr/bin/']
+Exec {path => ['/usr/bin/']}
 
 ## create startup script: for 'vagrant-mounted' event
 file {"vagrant-startup-script":

--- a/puppet/manifests/vagrant_mounted.pp
+++ b/puppet/manifests/vagrant_mounted.pp
@@ -1,5 +1,5 @@
 ## variables
-$MOUNTPOINT = '/vagrant/'
+$mountpoint = '/vagrant/'
 
 ## define $PATH for all execs, and packages
 Exec {path => ['/usr/bin/']}
@@ -24,8 +24,8 @@ file {"vagrant-startup-script":
                task
 
                script
-                   until mountpoint -q ${MOUNTPOINT}; do sleep 1; done
-                   /sbin/initctl emit --no-wait vagrant-mounted MOUNTPOINT=${MOUNTPOINT}
+                   until mountpoint -q ${mountpoint}; do sleep 1; done
+                   /sbin/initctl emit --no-wait vagrant-mounted MOUNTPOINT=${mountpoint}
                end script
                | EOT
                notify  => Exec["dos2unix-upstart-vagrant"],

--- a/puppet/manifests/vagrant_mounted.pp
+++ b/puppet/manifests/vagrant_mounted.pp
@@ -10,14 +10,14 @@ file {"vagrant-startup-script":
     ensure  => 'present',
     content => @("EOT"),
                #!upstart
-               description workaround for https://github.com/mitchellh/vagrant/issues/6074
+               description 'workaround for https://github.com/mitchellh/vagrant/issues/6074'
 
                ## start job defined in this file after system services, and processes have already loaded
                #       (to prevent conflict).
                #
                #  Note: this is a workaround for https://github.com/mitchellh/vagrant/issues/6074
                #
-               #  @filesystem,
+               #  @filesystem, an event that fires after all filesystems have mounted
                start on filesystem
 
                ## job will be blocked until the job has completely transitioned back to stopped
@@ -37,12 +37,12 @@ file {"vagrant-startup-script":
 #      'refreshonly => true' would be implemented on the corresponding listening end point. But, the
 #      'service' end point does not require the 'refreshonly' attribute.
 exec {"dos2unix-upstart-vagrant":
-    command => "dos2unix /etc/init/workaround-vagrant-bug-6074.conf",
-    notify  => Service["workaround-vagrant-bug-6074.conf"],
+    command => 'dos2unix /etc/init/workaround-vagrant-bug-6074.conf',
+#    notify  => Service['workaround-vagrant-bug-6074'],
 }
 
 ## start 'workaround-vagrant-bug-6074' service
-service {"workaround-vagrant-bug-6074.conf":
+service {'workaround-vagrant-bug-6074':
     ensure => 'running',
     enable => 'true',
 }

--- a/puppet/manifests/vagrant_mounted.pp
+++ b/puppet/manifests/vagrant_mounted.pp
@@ -25,5 +25,21 @@ file {"vagrant-startup-script":
                    /sbin/initctl emit --no-wait vagrant-mounted MOUNTPOINT=$MOUNTPOINT
                end script
                | EOT
-               notify  => Exec["dos2unix-upstart-${compiler}"],
+               notify  => Exec["dos2unix-upstart-vagrant"],
+}
+
+## dos2unix upstart: convert clrf (windows to linux) in case host machine is windows.
+#
+#  @notify, ensure the webserver service is started. This is similar to an exec statement, where the
+#      'refreshonly => true' would be implemented on the corresponding listening end point. But, the
+#      'service' end point does not require the 'refreshonly' attribute.
+exec {"dos2unix-upstart-vagrant":
+    command => "dos2unix /etc/init/vagrant.conf",
+    notify  => Service["vagrant"],
+}
+
+## start vagrant service
+service {"vagrant":
+    ensure => 'running',
+    enable => 'true',
 }

--- a/puppet/manifests/vagrant_mounted.pp
+++ b/puppet/manifests/vagrant_mounted.pp
@@ -1,5 +1,5 @@
 ## variables
-$MOUNTPOINT
+$MOUNTPOINT = '/vagrant/'
 
 ## define $PATH for all execs, and packages
 Exec {path => ['/usr/bin/']}

--- a/puppet/manifests/vagrant_mounted.pp
+++ b/puppet/manifests/vagrant_mounted.pp
@@ -14,9 +14,8 @@ file {"vagrant-startup-script":
                #
                #  Note: this is a workaround for https://github.com/mitchellh/vagrant/issues/6074
                #
-               #  @vagrant-mounted, an event that executes after the shared folder is mounted
-               #  @[2345], represents all configuration states with general linux, and networking access
-               start on (vagrant-mounted and runlevel [2345])
+               #  @filesystem,
+               start on filesystem
 
                ## job will be blocked until the job has completely transitioned back to stopped
                task

--- a/puppet/manifests/vagrant_mounted.pp
+++ b/puppet/manifests/vagrant_mounted.pp
@@ -15,12 +15,9 @@ file {"vagrant-startup-script":
                ## start job defined in this file after system services, and processes have already loaded
                #       (to prevent conflict).
                #
-               #  Note: this is a workaround for https://github.com/mitchellh/vagrant/issues/6074
-               #
                #  @filesystem, an event that fires after all filesystems have mounted
                start on filesystem
 
-               ## job will be blocked until the job has completely transitioned back to stopped
                task
 
                script


### PR DESCRIPTION
Partial #2046.

**Note:** we still need to add appropriate docblocks within `vagrant_mounted.pp`.  Specifically, within the heredoc upstart script, we need to comment the role of each upstart command.