### PR TITLE
#2093: .scss-lint.yml, remove unnecessary definition

### DIFF
--- a/test/linter/.scss-lint.yml
+++ b/test/linter/.scss-lint.yml
@@ -2,9 +2,6 @@
 #
 #      https://github.com/brigade/scss-lint/blob/master/config/default.yml
 linters:
-  BorderZero:
-    enabled: false
-
   Indentation:
     severity: warning
     width: 4


### PR DESCRIPTION
Resolves #2093.