### PR TITLE
#2470: Properly define 'directories' variable in 'log_directory.py'

### DIFF
--- a/puppet/environment/development/modules/system/manifests/log_directory.pp
+++ b/puppet/environment/development/modules/system/manifests/log_directory.pp
@@ -4,7 +4,7 @@
 ###
 class system::log_directory {
     ## variables
-    directories = [
+    $directories = [
         '/vagrant/log/database',
         '/vagrant/log/error',
         '/vagrant/log/warning',


### PR DESCRIPTION
Resolves #2470.