### PR TITLE
#2488: Ignore 'log/webcompiler/' within '.gitignore'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@
 /log/database
 /log/error
 /log/warning
+/log/webcompiler
 /log/info
 /log/debug
 /log/*.log


### PR DESCRIPTION
Resolves #2488.