### PR TITLE
#2590: Remove unnecessary syntax in 'webcompilers.erb'

### DIFF
--- a/puppet/environment/development/modules/compiler/templates/webcompilers.erb
+++ b/puppet/environment/development/modules/compiler/templates/webcompilers.erb
@@ -29,7 +29,7 @@ expect fork
 #
 #  @chdir, change the current working directory
 chdir <%= @compiler_dir %>
-exec ./<%= @compiler %> <%= @root_dir %>
+exec ./<%= @compiler %>
 
 ## log start-up date
 #


### PR DESCRIPTION
Resolves #2590.