### PR TITLE
#2655: Define 'redis' attributes in vagrant 'settings.yaml'

### DIFF
--- a/hiera/settings.yaml
+++ b/hiera/settings.yaml
@@ -18,7 +18,10 @@ general:
 
 ## redis
 redis:
+    bind_address: '127.0.0.1'
+    host: 'localhost'
     port: 6379
+    path: '/etc/redis/redis.conf'
 
 ## webserver
 webserver:


### PR DESCRIPTION
Resolves #2655.