### PR TITLE
#2674: Ensure 'build_docker' runs for OSX

### DIFF
--- a/build_docker
+++ b/build_docker
@@ -13,7 +13,7 @@ docker build -f redis.dockerfile -t container-redis .
 docker build -f webserver.dockerfile -t container-webserver .
 
 # run containers within common network
-if [ "$(uname -s)" == 'Linux' ]; then
+if [ "$(uname -s)" == 'Linux' ] || [ "$(uname -s)" == 'Darwin' ]; then
   docker network create -d bridge app_nw && \
   docker run --name base --net=app_nw -d container-default && \
   docker run --name redis --net=app_nw -d container-redis && \


### PR DESCRIPTION
Resolves #2674.